### PR TITLE
Fix function name in matmul.mbt

### DIFF
--- a/test/test_src/matmul.mbt
+++ b/test/test_src/matmul.mbt
@@ -28,7 +28,7 @@ fn matmul(l: Int, m: Int, n: Int, a: Array[Array[Double]], b: Array[Array[Double
 
 fn main {
   let dummy = Array::make(0, 0.0);
-  fn gen_arr(m: Int, n: Int) -> Array[Array[Double]] {
+  fn make_arr(m: Int, n: Int) -> Array[Array[Double]] {
     let mat = Array::make(m, dummy);
     fn init_arr(i: Int) -> Unit {
       if 0 <= i {


### PR DESCRIPTION
The test `matmul.mbt` fails locally, because the function name `gen_arr` and its usages `make_arr` are unmatched. This patch fixes it. Thanks for your review.