### PR TITLE
Fix build script

### DIFF
--- a/build_rvlinux.sh
+++ b/build_rvlinux.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 pushd libriscv/emulator
-./build.sh --no-C --native --64 -b -v
+./build.sh --C --native --64 -b -v
 popd
 ln -fs libriscv/emulator/.build/rvlinux .


### PR DESCRIPTION
When using the option `--no-C` to build the emulator, the following commands fail locally. The C-extension should be built too. So I change `--no-C` to `--C` in this patch. Thanks for your review.

```shell
$ zig build-exe -target riscv64-linux -femit-bin=./riscv_rt/test/print_int.o \
  ./riscv_rt/test/print_int.s ./riscv_rt/zig-out/lib/libmincaml.a \
  -O Debug -fno-strip -mcpu=baseline_rv64

$ ./libriscv/emulator/.build/rvlinux -n ./riscv_rt/test/print_int.o

Exception: ELF is a RISC-V RVC executable, however C-extension is not enabled.
```