### PR TITLE
Fix  global name

### DIFF
--- a/riscv_rt/test/float_int.s
+++ b/riscv_rt/test/float_int.s
@@ -1,6 +1,6 @@
-.global mincaml_main
+.global minimbt_main
 
-mincaml_main:
+minimbt_main:
     li a0, 1
     call mincaml_float_of_int
     call mincaml_int_of_float

--- a/riscv_rt/test/malloc.s
+++ b/riscv_rt/test/malloc.s
@@ -1,6 +1,6 @@
-.global mincaml_main
+.global minimbt_main
 
-mincaml_main:
+minimbt_main:
     li a0, 1024
     call mincaml_malloc
     li t0, 777

--- a/riscv_rt/test/print_int.s
+++ b/riscv_rt/test/print_int.s
@@ -1,6 +1,6 @@
-.global mincaml_main
+.global minimbt_main
 
-mincaml_main:
+minimbt_main:
     li a0, 666
     call mincaml_print_int
     li a0, 0


### PR DESCRIPTION
This patch fixes the `.global` name in files `*.s`. Thanks for your review.